### PR TITLE
Add swig build dependency

### DIFF
--- a/org.freedesktop.Sdk.Extension.llvm11.json
+++ b/org.freedesktop.Sdk.Extension.llvm11.json
@@ -12,6 +12,21 @@
   },
   "modules": [
     {
+      "name": "swig",
+      "config-opts": [
+        "--without-alllang",
+        "--with-python3"
+      ],
+      "cleanup": ["*"],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://download.sourceforge.net/swig/swig-4.0.1.tar.gz",
+          "sha256": "7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9"
+        }
+      ]
+    },
+    {
       "name": "llvm",
       "buildsystem": "cmake-ninja",
       "subdir": "llvm",


### PR DESCRIPTION
swig is needed during lldb build in order to enable python scripting support.