### PR TITLE
Create 22.08 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Example:
 {
   "id" : "org.example.MyApp",
   "runtime" : "org.freedesktop.Platform",
-  "runtime-version" : "20.08",
+  "runtime-version" : "22.08",
   "sdk" : "org.freedesktop.Sdk",
   "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.llvm11" ],
   "modules" : [

--- a/org.freedesktop.Sdk.Extension.llvm11.json
+++ b/org.freedesktop.Sdk.Extension.llvm11.json
@@ -1,10 +1,10 @@
 {
   "id": "org.freedesktop.Sdk.Extension.llvm11",
-  "branch": "20.08",
+  "branch": "22.08",
   "runtime": "org.freedesktop.Sdk",
   "build-extension": true,
   "sdk": "org.freedesktop.Sdk",
-  "runtime-version": "20.08",
+  "runtime-version": "22.08",
   "separate-locales": false,
   "appstream-compose": false,
   "build-options": {


### PR DESCRIPTION
The Freedesktop runtime version 22.08 is still supported until next year, so I created a PR for the 22.08 runtime [_as well as_ the 23.08 runtime](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm11/pull/15).